### PR TITLE
Improve error reporting and connection shutdown handling

### DIFF
--- a/go/pondsocket/lobby.go
+++ b/go/pondsocket/lobby.go
@@ -140,6 +140,7 @@ func (l *Lobby) createChannelUnsafe(name string) (*Channel, error) {
 		Outgoing:             l.outgoing,
 		InternalQueueTimeout: l.endpoint.options.InternalQueueTimeout,
 		PubSub:               l.endpoint.options.PubSub,
+		Hooks:                l.endpoint.options.Hooks,
 	}
 	c := newChannel(l.endpoint.ctx, opts)
 

--- a/go/pondsocket/presence.go
+++ b/go/pondsocket/presence.go
@@ -249,6 +249,8 @@ func (p *presenceClient) requestPresenceSync(requesterUserID string) {
 		return
 	}
 	go func() {
-		_ = p.channel.pubsub.Publish(topic, data)
+		if err := p.channel.pubsub.Publish(topic, data); err != nil {
+			p.channel.reportError("pubsub_publish", err)
+		}
 	}()
 }

--- a/go/pondsocket/types.go
+++ b/go/pondsocket/types.go
@@ -66,6 +66,7 @@ type options struct {
 	OnDestroy            func() error
 	InternalQueueTimeout time.Duration
 	PubSub               PubSub
+	Hooks                *Hooks
 }
 
 type recipient string


### PR DESCRIPTION
## Summary
- allow `NewServer` to accept nil options and surface listener failures through the manager’s metrics hook
- clone manager options instead of mutating the caller’s struct and ensure HTTP errors produce responses while being reported
- harden connection/channel shutdown by waiting for readers, propagating handler failures, and reporting PubSub errors via hooks

## Testing
- go test ./... -vet=off -count=1 *(fails: github.com/eleven-am/pondsocket/go/pondsocket/distributed requires redis)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ba641ac08326bfe341cd78cacdd9