### PR TITLE
Improve connection management and server startup handling

### DIFF
--- a/go/pondsocket/arrays.go
+++ b/go/pondsocket/arrays.go
@@ -31,9 +31,9 @@ func (a *array[T]) find(predicate arrayPredicate[T]) *T {
 	a.lock.RLock()
 	defer a.lock.RUnlock()
 
-	for _, item := range a.items {
-		if predicate(item) {
-			return &item
+	for i := range a.items {
+		if predicate(a.items[i]) {
+			return &a.items[i]
 		}
 	}
 	return nil

--- a/go/pondsocket/distributed/example_test.go
+++ b/go/pondsocket/distributed/example_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/eleven-am/pondsocket/go/pondsocket/distributed"
+	"github.com/redis/go-redis/v9"
 )
 
 // Example demonstrates how to use RedisPubSub with PondSocket


### PR DESCRIPTION
## Summary
- ensure array lookups return pointers to slice elements rather than loop copies
- surface missing connections when closing and still close available ones
- start the HTTP server on an explicit listener to report binding failures
- add the missing Redis import required by the distributed example tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f65c10f7ac8326a36ca6b286754c8e